### PR TITLE
Fix provider loading if only one provider is available

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -290,6 +290,9 @@ class ProviderService implements IProviderService {
 	 */
 	private function loadProvidersFromList(string $appId, array $providers) {
 		$version = $this->configService->getCloudVersion();
+		if (array_key_exists('@attributes', $providers)) {
+			$providers = [$providers];
+		}
 		foreach ($providers AS $provider) {
 			if (is_array($provider)) {
 				$attributes = $provider['@attributes'];


### PR DESCRIPTION
If only one provider is available, providers just contains the one entry but is not iterable, so the foreach loop cannot access the attributes properly

![image](https://user-images.githubusercontent.com/3404133/56650593-a6689280-6687-11e9-9fd6-c08157714bae.png)

Fixes https://github.com/nextcloud/fulltextsearch/issues/487