### PR TITLE
Resilience: Use TArrayTools::getArray() for setErrors()

### DIFF
--- a/lib/Db/IndexesRequestBuilder.php
+++ b/lib/Db/IndexesRequestBuilder.php
@@ -122,7 +122,7 @@ class IndexesRequestBuilder extends CoreRequestBuilder {
 			  ->setLastIndex($this->getInt('indexed', $data, 0));
 		$index->setOptions($this->getArray('options', $data, []));
 		$index->setErrorCount($this->getInt('err', $data, 0));
-		$index->setErrors(json_decode($data['message'], true));
+		$index->setErrors($this->getArray('message', $data, []));
 
 		return $index;
 	}


### PR DESCRIPTION
Fixes the following error: 
```
TypeError: Argument 1 passed to OCA\FullTextSearch\Model\Index::setErrors() 
must be of the type array, null given, 
called in nextcloud/apps/fulltextsearch/lib/Db/IndexesRequestBuilder.php on line 125
```