### PR TITLE
Log message if information on provider indexed state is not available

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -226,6 +226,11 @@ class ProviderService implements IProviderService {
 				$providerId, ConfigService::PROVIDER_INDEXED
 			);
 		} catch (ProviderOptionsDoesNotExistException $e) {
+			$this->miscService->log('Could not determine if provider with id ' 
+			. $providerId 
+			. ' was properly indexed because the corresponding provider-option could not be found.'
+			. ' Make sure the initial indexing process has been completed successfully.'
+			);
 			return false;
 		}
 


### PR DESCRIPTION
Improval for finding errors like this one mentioned here: https://help.nextcloud.com/t/fulltextsearch-no-response-in-nc-ui/67740/4