### PR TITLE
Register services during registration instead of boot

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -48,6 +48,7 @@ use OCP\INavigationManager;
 use OCP\IServerContainer;
 use OCP\IURLGenerator;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Psr\Container\ContainerInterface;
 use Throwable;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -76,6 +77,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerCapability(Capabilities::class);
 		$context->registerSearchProvider(UnifiedSearchProvider::class);
+		$this->registerServices($this->getContainer());
 	}
 
 	/**
@@ -84,7 +86,6 @@ class Application extends App implements IBootstrap {
 	 * @throws Throwable
 	 */
 	public function boot(IBootContext $context): void {
-		$context->injectFn(Closure::fromCallable([$this, 'registerServices']));
 		$context->injectFn(Closure::fromCallable([$this, 'registerNavigation']));
 	}
 
@@ -92,9 +93,9 @@ class Application extends App implements IBootstrap {
 	/**
 	 * Register Navigation Tab
 	 *
-	 * @param IServerContainer $container
+	 * @param ContainerInterface $container
 	 */
-	protected function registerServices(IServerContainer $container) {
+	protected function registerServices(ContainerInterface $container) {
 		/** @var IFullTextSearchManager $fullTextSearchManager */
 		$fullTextSearchManager = $container->get(IFullTextSearchManager::class);
 


### PR DESCRIPTION
This will allow all apps to use a propery setup fulltextsearch manager instance when they try to access it during their own boot method

- ~Check if still needed, as i remeber when only accessing the FTS Manager at a later stage there was no issue in deck anymore~ 

While not required anymore for deck to work services should be registered in the register method to make sure they are available in case queried by other apps:

> In each installed and enabled app that has an Application class that also implements IBootstrap, the register method will be called. This method receives a context argument via which the app can prime the dependency injection container and register other services lazily, e.g. by calling $context->registerService(...). The emphasis is on lazyness. At this very early stage of the process lifetime, no other apps nor all of the server components are ready. Therefore the app must not try to use anything except the API provided by the context. That shall ensure that all apps can safely run their registration logic before any services are queried (instantiated) from the DI container or related code is run.

https://docs.nextcloud.com/server/latest/developer_manual/app_development/bootstrap.html#nextcloud-20-and-later