### PR TITLE
set internal collection

### DIFF
--- a/lib/Db/IndexesRequest.php
+++ b/lib/Db/IndexesRequest.php
@@ -53,6 +53,10 @@ class IndexesRequest extends IndexesRequestBuilder {
 	 * @return bool
 	 */
 	public function create(Index $index): bool {
+		if (empty($index->getCollection())) {
+			$index->setCollection($this->configService->getInternalCollection());
+		}
+
 		$qb = $this->getIndexesInsertSql();
 		$qb->setValue('owner_id', $qb->createNamedParameter($index->getOwnerId()))
 		   ->setValue('provider_id', $qb->createNamedParameter($index->getProviderId()))
@@ -183,7 +187,7 @@ class IndexesRequest extends IndexesRequestBuilder {
 	 * @param int $status
 	 */
 	public function updateStatuses(string $collection, string $providerId, array $indexes, int $status) {
-		$collection = ($collection === '') ? CollectionService::LOCAL : $collection;
+		$collection = ($collection === '') ? $this->configService->getInternalCollection() : $collection;
 
 		$qb = $this->getIndexesUpdateSql();
 		$qb->set('status', $qb->createNamedParameter($status));
@@ -213,7 +217,7 @@ class IndexesRequest extends IndexesRequestBuilder {
 	 * @param string $collection \
 	 */
 	public function deleteCollection(string $collection): void {
-		$collection = ($collection === '') ? CollectionService::LOCAL : $collection;
+		$collection = ($collection === '') ? $this->configService->getInternalCollection() : $collection;
 
 		$qb = $this->getIndexesDeleteSql();
 		$this->limitToCollection($qb, $collection);
@@ -237,7 +241,7 @@ class IndexesRequest extends IndexesRequestBuilder {
 	 *
 	 */
 	public function reset(string $collection = ''): void {
-		$collection = ($collection === '') ? CollectionService::LOCAL : $collection;
+		$collection = ($collection === '') ? $this->configService->getInternalCollection() : $collection;
 
 		$qb = $this->getIndexesDeleteSql();
 		$this->limitToCollection($qb, $collection);
@@ -256,7 +260,7 @@ class IndexesRequest extends IndexesRequestBuilder {
 	 * @throws IndexDoesNotExistException
 	 */
 	public function getIndex(string $providerId, string $documentId, string $collection = ''): Index {
-		$collection = ($collection === '') ? CollectionService::LOCAL : $collection;
+		$collection = ($collection === '') ? $this->configService->getInternalCollection() : $collection;
 
 		$qb = $this->getIndexesSelectSql();
 		$this->limitToProviderId($qb, $providerId);
@@ -305,7 +309,7 @@ class IndexesRequest extends IndexesRequestBuilder {
 	 * @return Index[]
 	 */
 	public function getQueuedIndexes(string $collection = '', bool $all = false, int $length = 0): array {
-		$collection = ($collection === '') ? CollectionService::LOCAL : $collection;
+		$collection = ($collection === '') ? $this->configService->getInternalCollection() : $collection;
 
 		$qb = $this->getIndexesSelectSql();
 		$this->limitToQueuedIndexes($qb);
@@ -374,7 +378,7 @@ class IndexesRequest extends IndexesRequestBuilder {
 			return $collections;
 		}
 
-		return array_merge([CollectionService::LOCAL], $collections);
+		return array_merge([$this->configService->getInternalCollection()], $collections);
 	}
 
 

--- a/lib/Migration/Version2801Date202309200001.php
+++ b/lib/Migration/Version2801Date202309200001.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\FullTextSearch\Migration;
+
+use Closure;
+use OCP\DB\Exception;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version2801Date202309200001 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	private $dbConnection;
+
+	/**
+	 * @param IDBConnection $dbConnection
+	 */
+	public function __construct(IDBConnection $dbConnection) {
+		$this->dbConnection = $dbConnection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @throws Exception
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('fulltextsearch_index')) {
+			return;
+		}
+
+		$qb = $this->dbConnection->getQueryBuilder();
+		$expr = $qb->expr();
+		$orX = $expr->orX();
+		$orX->add($expr->eq('collection', $qb->createNamedParameter('')));
+		$orX->add($expr->isNull('collection'));
+
+		$qb->update('fulltextsearch_index')
+		   ->set('collection', $qb->createNamedParameter('local'))
+		   ->where($orX);
+		$qb->executeStatement();
+	}
+
+}

--- a/lib/Model/Index.php
+++ b/lib/Model/Index.php
@@ -55,7 +55,7 @@ class Index implements IIndex, JsonSerializable {
 	/** @var string */
 	private $documentId;
 
-	private string $collection = CollectionService::LOCAL;
+	private string $collection = '';
 
 	/** @var string */
 	private $source = '';

--- a/lib/Service/CollectionService.php
+++ b/lib/Service/CollectionService.php
@@ -45,8 +45,6 @@ use OCP\IURLGenerator;
 
 
 class CollectionService {
-	public const LOCAL = 'local';
-
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
@@ -222,7 +220,7 @@ class CollectionService {
 	 * @throws CollectionArgumentException
 	 */
 	public function confirmCollectionString(string $collection): void {
-		if (strtolower($collection) === self::LOCAL) {
+		if (strtolower($collection) === $this->configService->getInternalCollection()) {
 			throw new CollectionArgumentException('invalid name');
 		}
 	}

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -53,7 +53,7 @@ class ConfigService {
 	const CRON_LAST_ERR_RESET = 'cron_err_reset';
 	const TICK_TTL = 'tick_ttl';
 	const COLLECTION_INDEXING_LIST = 'collection_indexing_list';
-
+	const COLLECTION_INTERNAL = 'collection_internal';
 
 	// Temp. can be removed after few major releases
 	const MIGRATION_24 = 'migration_24';
@@ -66,7 +66,8 @@ class ConfigService {
 		self::CRON_LAST_ERR_RESET => '0',
 		self::TICK_TTL => '1800',
 		self::COLLECTION_INDEXING_LIST => 50,
-		self::MIGRATION_24 => 1
+		self::MIGRATION_24 => 1,
+		self::COLLECTION_INTERNAL => 'local'
 	];
 
 
@@ -143,12 +144,12 @@ class ConfigService {
 	 * @return string
 	 */
 	public function getAppValue(string $key): string {
-		$defaultValue = '';
-		if (array_key_exists($key, $this->defaults)) {
-			$defaultValue = $this->defaults[$key];
-		}
-
-		return (string)$this->config->getAppValue(Application::APP_ID, $key, $defaultValue);
+		return $this->config->getSystemValueString(
+			Application::APP_ID . '.' . $key,
+			(string)$this->config->getAppValue(Application::APP_ID,
+				$key,
+				$this->defaults[$key] ?? '')
+		);
 	}
 
 	/**
@@ -303,5 +304,9 @@ class ConfigService {
 		}
 
 		throw new DatabaseException('please run ./occ fulltextsearch:migration:24');
+	}
+
+	public function getInternalCollection(): string {
+		return $this->getAppValue(self::COLLECTION_INTERNAL);
 	}
 }


### PR DESCRIPTION
- allow and prioritize the configuration of the app via `config.php` [1],
- fix an issue with empty collection name during index, and fix empty entries from database with a migration script,
- customize internal collection name using the config app `collection_internal`
 
_[1] (example)_
```
  'fulltextsearch.collection_internal' => 'my_new_internal_collection',
```