### PR TITLE
PlatformTemporaryException

### DIFF
--- a/lib/Command/Index.php
+++ b/lib/Command/Index.php
@@ -35,6 +35,7 @@ use OCA\FullTextSearch\Tools\Traits\TArrayTools;
 use Exception;
 use OC\Core\Command\InterruptedException;
 use OCA\FullTextSearch\ACommandBase;
+use OCA\FullTextSearch\Exceptions\PlatformTemporaryException;
 use OCA\FullTextSearch\Exceptions\TickDoesNotExistException;
 use OCA\FullTextSearch\Model\Index as ModelIndex;
 use OCA\FullTextSearch\Model\IndexOptions;
@@ -287,19 +288,6 @@ class Index extends ACommandBase {
 		$this->runner->setInfo('documentCurrent', 'all');
 		$this->runner->stop();
 
-//		while (true) {
-//			$this->runner->updateAction('_indexOver', true);
-//			$pressed = strtolower($this->updateAction(''));
-//			if ($pressed === $this->keys['nextStep']) {
-//				$this->pauseRunning(false);
-//				break;
-//			}
-//			usleep(300000);
-//		}
-
-
-//		$output->writeLn('');
-
 		return 0;
 	}
 
@@ -412,9 +400,9 @@ class Index extends ACommandBase {
 			}
 
 			try {
-				$this->indexService->indexProviderContentFromUser(
-					$platform, $provider, $user->getUID(), $options
-				);
+				$this->indexService->indexProviderContentFromUser($platform, $provider, $user->getUID(), $options);
+			} catch (PlatformTemporaryException $e) {
+				throw $e;
 			} catch (Exception $e) {
 				continue;
 			}

--- a/lib/Exceptions/PlatformTemporaryException.php
+++ b/lib/Exceptions/PlatformTemporaryException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * FullTextSearch - Full text search framework for Nextcloud
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2023
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\FullTextSearch\Exceptions;
+
+use Exception;
+
+/**
+ * @deprecated - nc28 use \OCP\FullTextSearch\Exceptions\PlatformTemporaryException
+ */
+class PlatformTemporaryException extends Exception {
+}

--- a/lib/Service/IndexService.php
+++ b/lib/Service/IndexService.php
@@ -35,6 +35,7 @@ use Exception;
 use OCA\FullTextSearch\Db\IndexesRequest;
 use OCA\FullTextSearch\Exceptions\IndexDoesNotExistException;
 use OCA\FullTextSearch\Exceptions\NotIndexableDocumentException;
+use OCA\FullTextSearch\Exceptions\PlatformTemporaryException;
 use OCA\FullTextSearch\Exceptions\ProviderDoesNotExistException;
 use OCA\FullTextSearch\Model\Index;
 use OCA\FullTextSearch\Model\IndexOptions;
@@ -323,7 +324,8 @@ class IndexService implements IIndexService {
 
 				$index = $this->indexDocument($platform, $document);
 				$this->updateIndex($index);
-
+			} catch (PlatformTemporaryException $e) {
+				throw $e;
 			} catch (Exception $e) {
 			}
 
@@ -371,10 +373,11 @@ class IndexService implements IIndexService {
 
 		try {
 			return $platform->indexDocument($document);
+		} catch (PlatformTemporaryException $e) {
+			throw $e;
 		} catch (Exception $e) {
 			throw new IndexDoesNotExistException();
 		}
-
 	}
 
 
@@ -383,6 +386,7 @@ class IndexService implements IIndexService {
 	 * @param IFullTextSearchProvider $provider
 	 * @param Index $index
 	 *
+	 * @throws PlatformTemporaryException
 	 * @throws Exception
 	 */
 	public function updateDocument(


### PR DESCRIPTION
manage PlatformTemporaryException:

- during `fulltextsearch:index`: will stop the process,
- during `fulltextsearch:live`: will stop queue processing and try to reconnected after few seconds,
- during background index: will stop and try again next cron tick