### PR TITLE
Move closeCursor into catch block

### DIFF
--- a/lib/Migration/Version2801Date202309200001.php
+++ b/lib/Migration/Version2801Date202309200001.php
@@ -86,9 +86,7 @@ class Version2801Date202309200001 extends SimpleMigrationStep {
 					$delete->executeStatement();
 				}
 			}
-			if ($result !== null) {
-				$result->closeCursor();
-			}
+			$result->closeCursor();
 		}
 
 	}

--- a/lib/Migration/Version2801Date202309200001.php
+++ b/lib/Migration/Version2801Date202309200001.php
@@ -86,8 +86,10 @@ class Version2801Date202309200001 extends SimpleMigrationStep {
 					$delete->executeStatement();
 				}
 			}
+			if ($result !== null) {
+				$result->closeCursor();
+			}
 		}
 
-		$result->closeCursor();
 	}
 }


### PR DESCRIPTION
Otherwise, $result is not initialised and closeCursor fails. Fixes #813 Fixes #818