### PR TITLE
Update Runner.php to avoid "Force Quit" situation and allow the job to be finished

### DIFF
--- a/lib/Model/Runner.php
+++ b/lib/Model/Runner.php
@@ -393,12 +393,18 @@ class Runner implements IRunner {
 
 		try {
 			$this->runningService->update($this->tickId, $action);
+			$this->tickUpdate = $tick;
 		} catch (TickIsNotAliveException $e) {
-			$this->output('Force Quit');
-			exit();
+			$this->output('No Force Quit');
+			/**
+                         * ToDo: we must collect all errors and publish the error messages once the job finishes 
+			 * to allow the admin or the user to fix the problems or accept that not all files are indexed.
+   			 * Obviously there are probably many more files not indexed if the "Force Quit" cause can not be fixed for some reason.
+                         * exit();
+                        */
 		}
 
-		$this->tickUpdate = $tick;
+		
 	}
 
 


### PR DESCRIPTION
…o finish

This is obviously only a quick fix for those who prefer to get most files indexed and can live with the fact that some are not.  Especially many pdf's won't be indexed anyhow unless ocrmypdf is installed and working.  Hetzner does not provide ocrmypdf for performance reasons.