### PR TITLE
fix(test): Remove non-matching search terms

### DIFF
--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -373,7 +373,7 @@ class Test extends ACommandBase {
 			[TestService::DOCUMENT_TYPE_SIMPLE]
 		);
 		$this->search(
-			$output, $testPlatform, $testProvider, $access, 'document is a simple test',
+			$output, $testPlatform, $testProvider, $access, 'document',
 //			[TestService::DOCUMENT_TYPE_SIMPLE]
 			[TestService::DOCUMENT_TYPE_SIMPLE, TestService::DOCUMENT_TYPE_LICENSE]
 		);
@@ -386,7 +386,7 @@ class Test extends ACommandBase {
 			[TestService::DOCUMENT_TYPE_SIMPLE]
 		);
 		$this->search(
-			$output, $testPlatform, $testProvider, $access, 'document is a simple -test',
+			$output, $testPlatform, $testProvider, $access, 'document -test',
 			[TestService::DOCUMENT_TYPE_LICENSE]
 		);
 		$this->search(
@@ -410,7 +410,7 @@ class Test extends ACommandBase {
 			[]
 		);
 		$this->search(
-			$output, $testPlatform, $testProvider, $access, '+document is a simple -test -testing',
+			$output, $testPlatform, $testProvider, $access, '+document -test -testing',
 			[TestService::DOCUMENT_TYPE_LICENSE]
 		);
 		$this->search(


### PR DESCRIPTION
The Elasticsearch platform silently ignores search terms that don't match, as long as there are also enough matching terms.

Thus, the search for 'document is a simple test' returns the license file although it doesn't contain the words "simple" or "test" or any variation thereof.

Since the semantics of full text search aren't clearly defined, it should be up to the platform to decide how to handle non-matching search terms. So not returning the license in this case is just as valid!

Case in point is PostgreSQL, which strictly requires every searched term (except for stopwords) to be contained in the search results (after normalization). These changes make the test harness pass on that platform, too.