### PR TITLE
fix(Command): try to actualize values for document indexing

### DIFF
--- a/lib/Command/DocumentIndex.php
+++ b/lib/Command/DocumentIndex.php
@@ -57,6 +57,11 @@ class DocumentIndex extends Base {
 		$index = new Index($providerId, $documentId);
 		$index->setOwnerId($userId);
 		$index->setStatus(Index::INDEX_FULL);
+		try {
+			$index = \OC::$server->get(\OCA\FullTextSearch\Service\IndexService::class)->getIndex($providerId, $documentId);
+		} catch (\Throwable $t) {
+			$output->writeln("<error>Index not found : index attribute has been set to default values</error>");
+		}
 		$indexDocument = $provider->updateDocument($index);
 		if (!$indexDocument->hasIndex()) {
 			$indexDocument->setIndex($index);

--- a/lib/Command/DocumentProvider.php
+++ b/lib/Command/DocumentProvider.php
@@ -58,6 +58,11 @@ class DocumentProvider extends Base {
 		$index = new Index($providerId, $documentId);
 		$index->setOwnerId($userId);
 		$index->setStatus(Index::INDEX_FULL);
+		try {
+			$index = \OC::$server->get(\OCA\FullTextSearch\Service\IndexService::class)->getIndex($providerId, $documentId);
+		} catch (\Throwable $t) {
+			$output->writeln("<error>Index not found : index attribute has been set to default values</error>");
+		}
 		$indexDocument = $provider->updateDocument($index);
 
 		$index->setOwnerId($indexDocument->getAccess()->getOwnerId());


### PR DESCRIPTION
OCC commands `fulltextsearch:document:provider` and `fulltextsearch:document:index` return invalid values for the "collection", "status" and "lastIndex" fields of the document index.
In fact, the commands display index values even if the index does not exist for the specified document. If the index exists, the values present in the database are not displayed, but are replaced by default values.