### PR TITLE
feat: specify portions of document to be passed from platform to provider

### DIFF
--- a/lib/Model/SearchRequest.php
+++ b/lib/Model/SearchRequest.php
@@ -11,6 +11,7 @@ namespace OCA\FullTextSearch\Model;
 
 use JsonSerializable;
 use OCA\FullTextSearch\Tools\Traits\TArrayTools;
+use OCP\FullTextSearch\Model\BodyPortion;
 use OCP\FullTextSearch\Model\ISearchRequest;
 use OCP\FullTextSearch\Model\ISearchRequestSimpleQuery;
 
@@ -78,6 +79,9 @@ class SearchRequest implements ISearchRequest, JsonSerializable {
 
 	/** @var array */
 	private $simpleQueries = [];
+
+	/** @var list<string> */
+	private array $portions = [];
 
 
 	/**
@@ -688,6 +692,26 @@ class SearchRequest implements ISearchRequest, JsonSerializable {
 	 */
 	public function getSimpleQueries(): array {
 		return $this->simpleQueries;
+	}
+
+
+	/**
+	 * @param BodyPortion $portion
+	 *
+	 * @return ISearchRequest
+	 */
+	public function addPortion(BodyPortion $portion): ISearchRequest {
+		$this->portions[] = $portion->value;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	public function getPortions(): array {
+		return $this->portions;
 	}
 
 


### PR DESCRIPTION
Right now, FTS platform `fulltextsearch_elasticsearch` [returns](https://github.com/nextcloud/fulltextsearch_elasticsearch/blob/master/lib/Service/SearchService.php#L196) an arbitrary set of data among those stored in the index, ignoring tags, subtags, metatags and more (pun intended).

It is fine to no fetch and pass everything all the time, but sometime a provider may find convenient to just reuse data already attached to a document instead of retrieve all of them from scratch.

Use case: I'm hacking a FTS provider for mail, and I have lots of structured data to index, to filter in search requests (e.g. `from:` filters), and to use while displaying the response (e.g. `from` can be used to retrieve the avatar of the message sender). Retrieve all of them again from the database (or, even worse: from the IMAP server) for each search result may become a bit inefficient.

Rationale of this proposal is to provide a method for the provider to specify (eventually in own implementation of `IFullTextSearchProvider::improveSearchRequest()`) the list of parts required back from the platform. A mere list of strings in `SearchRequest`, meant to be read and handled from the platform.



Sample implied implementation of changes in `SearchMappingService::generateSearchQueryParams()` ([here](https://github.com/nextcloud/fulltextsearch_elasticsearch/blob/master/lib/Service/SearchMappingService.php#L65)):

```
$params = [
	'index' => $this->configService->getElasticIndex(),
	'size' => $request->getSize(),
	'from' => (($request->getPage() - 1) * $request->getSize()),
	'_source_excludes' => 'content',
	'_source_includes' => join(',', $request->getPortions()),   // <----- this line!
];
```

and `SearchService::parseSearchEntry()` also would require some adjustment (which I can provide myself if this is approved!).